### PR TITLE
hepfile.load output can directly be written to a hepfile 

### DIFF
--- a/sandbox/play_with_input_vs_output.ipynb
+++ b/sandbox/play_with_input_vs_output.ipynb
@@ -13,16 +13,7 @@
    "execution_count": 1,
    "id": "0a308265-8e23-42aa-b2df-13eae4b373a4",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/nfranz/research/hepfile/src/hepfile/write.py:562: SyntaxWarning: \"is not\" with a literal. Did you mean \"!=\"?\n",
-      "  if group == \"_SINGLETONS_GROUP_\" and dataset is not \"COUNTER\":\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# imports\n",
     "import hepfile as hf"
@@ -116,7 +107,14 @@
       "Adding dataset \u001b[1mpy\u001b[0m to the dictionary under group \u001b[1mmuons\u001b[0m.\n",
       "Adding dataset \u001b[1mnParticles\u001b[0m to the dictionary as a SINGLETON.\n",
       "Writing the hdf5 file from the awkward array...\n",
-      "{'_SINGLETONS_GROUP_/COUNTER': <class 'int'>, 'jet/njet': <class 'int'>, 'jet/px': <class 'numpy.int64'>, 'jet/py': <class 'numpy.int64'>, 'muons/nmuons': <class 'int'>, 'muons/px': <class 'numpy.int64'>, 'muons/py': <class 'numpy.int64'>, 'nParticles': <class 'numpy.int64'>}\n",
+      "_SINGLETONS_GROUP_ COUNTER\n",
+      "_SINGLETONS_GROUP_ nParticles\n",
+      "jet njet\n",
+      "jet px\n",
+      "jet py\n",
+      "muons nmuons\n",
+      "muons px\n",
+      "muons py\n",
       "_SINGLETONS_GROUP_/COUNTER       has 2            entries\n",
       "jet/njet                         has 2            entries\n",
       "muons/nmuons                     has 2            entries\n",
@@ -190,7 +188,7 @@
     {
      "data": {
       "text/plain": [
-       "{'_GROUPS_', '_MAP_DATASETS_TO_DATA_TYPES_', '_PROTECTED_NAMES_'}"
+       "{'_PROTECTED_NAMES_'}"
       ]
      },
      "execution_count": 7,
@@ -271,7 +269,7 @@
        "  'muons/py',\n",
        "  'nParticles'],\n",
        " '_NUMBER_OF_BUCKETS_': 2,\n",
-       " '_SINGLETONS_GROUP_': ['nParticles'],\n",
+       " '_SINGLETONS_GROUP_': array(['nParticles', 'COUNTER'], dtype='<U10'),\n",
        " '_SINGLETONS_GROUP_/COUNTER': array([1, 1]),\n",
        " '_SINGLETONS_GROUP_/COUNTER_INDEX': array([0, 1]),\n",
        " 'jet/njet': array([3, 4]),\n",
@@ -282,7 +280,19 @@
        " 'jet/py': array([1, 2, 3, 3, 4, 6, 7]),\n",
        " 'muons/px': array([1, 2, 3, 3, 4, 6, 7]),\n",
        " 'muons/py': array([1, 2, 3, 3, 4, 6, 7]),\n",
-       " 'nParticles': array([3, 4])}"
+       " 'nParticles': array([3, 4]),\n",
+       " '_GROUPS_': {'_SINGLETONS_GROUP_': ['nParticles', 'COUNTER'],\n",
+       "  'jet': ['njet', 'px', 'py'],\n",
+       "  'muons': ['nmuons', 'px', 'py']},\n",
+       " '_MAP_DATASETS_TO_DATA_TYPES_': {'_SINGLETONS_GROUP_': dtype('<U10'),\n",
+       "  '_SINGLETONS_GROUP_/COUNTER': dtype('int64'),\n",
+       "  'jet/njet': dtype('int64'),\n",
+       "  'jet/px': dtype('int64'),\n",
+       "  'jet/py': dtype('int64'),\n",
+       "  'muons/nmuons': dtype('int64'),\n",
+       "  'muons/px': dtype('int64'),\n",
+       "  'muons/py': dtype('int64'),\n",
+       "  'nParticles': dtype('int64')}}"
       ]
      },
      "execution_count": 9,
@@ -360,7 +370,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'_SINGLETONS_GROUP_/COUNTER': <class 'int'>, 'jet/njet': <class 'int'>, 'jet/px': <class 'numpy.int64'>, 'jet/py': <class 'numpy.int64'>, 'muons/nmuons': <class 'int'>, 'muons/px': <class 'numpy.int64'>, 'muons/py': <class 'numpy.int64'>, 'nParticles': <class 'numpy.int64'>}\n",
+      "_SINGLETONS_GROUP_ nParticles\n",
+      "Writing nParticles to file\n",
+      "\tWriting to file...\n",
+      "Writing to file nParticles as type int64\n",
+      "_SINGLETONS_GROUP_ COUNTER\n",
+      "Writing _SINGLETONS_GROUP_/COUNTER to file\n",
+      "\tWriting to file...\n",
+      "Writing to file _SINGLETONS_GROUP_/COUNTER as type int64\n",
+      "jet njet\n",
+      "Writing jet/njet to file\n",
+      "\tWriting to file...\n",
+      "Writing to file jet/njet as type int64\n",
+      "jet px\n",
+      "Writing jet/px to file\n",
+      "\tWriting to file...\n",
+      "Writing to file jet/px as type int64\n",
+      "jet py\n",
+      "Writing jet/py to file\n",
+      "\tWriting to file...\n",
+      "Writing to file jet/py as type int64\n",
+      "muons nmuons\n",
+      "Writing muons/nmuons to file\n",
+      "\tWriting to file...\n",
+      "Writing to file muons/nmuons as type int64\n",
+      "muons px\n",
+      "Writing muons/px to file\n",
+      "\tWriting to file...\n",
+      "Writing to file muons/px as type int64\n",
+      "muons py\n",
+      "Writing muons/py to file\n",
+      "\tWriting to file...\n",
+      "Writing to file muons/py as type int64\n",
       "_SINGLETONS_GROUP_/COUNTER       has 2            entries\n",
       "jet/njet                         has 2            entries\n",
       "muons/nmuons                     has 2            entries\n",
@@ -379,11 +420,7 @@
     }
    ],
    "source": [
-    "from copy import deepcopy\n",
-    "xnew = deepcopy(x)\n",
-    "xnew['_GROUPS_'] = d['_GROUPS_']\n",
-    "xnew['_MAP_DATASETS_TO_DATA_TYPES_'] = d['_MAP_DATASETS_TO_DATA_TYPES_']\n",
-    "hf.write_to_file('test2.h5', xnew)"
+    "hf.write_to_file('test2.h5', x, verbose=True)"
    ]
   },
   {

--- a/src/hepfile/write.py
+++ b/src/hepfile/write.py
@@ -545,8 +545,6 @@ def write_to_file(
             compression_opts=comp_opts,
         )
 
-        print(data['_MAP_DATASETS_TO_DATA_TYPES_'])
-
         for group in _GROUPS_:
             
             hdoutfile.create_group(group)
@@ -557,16 +555,16 @@ def write_to_file(
             datasets = data["_GROUPS_"][group]
         
             for dataset in datasets:
-
+                print(group, dataset)
                 name = None
-                if group == "_SINGLETONS_GROUP_" and dataset is not "COUNTER":
+                if group == "_SINGLETONS_GROUP_" and dataset != "COUNTER":
                     name = dataset
                 else:
                     name = "%s/%s" % (group, dataset)
 
                 if verbose is True:
                     print(f"Writing {name} to file")
-
+                
                 x = data[name]
 
                 dataset_dtype = data['_MAP_DATASETS_TO_DATA_TYPES_'][name]


### PR DESCRIPTION
This can be done using `hepfile.write_to_file` now! See issue #33 for a discussion on this issue.

Note: the output of `hepfile.load` does not exactly match the input to `hepfile.write_to_file` if created from scratch because extra data is computed and added to the hepfile purposely!